### PR TITLE
Add type hints to lambda parameters.

### DIFF
--- a/src/StringDiff.php
+++ b/src/StringDiff.php
@@ -134,7 +134,7 @@ final class StringDiff extends Diff {
     invariant($old_start !== null, 'failed to find an old pos');
     invariant($new_start !== null, 'failed to find a new pos');
 
-    $format = ($start, $lines) ==> ($start === 1 && $lines === 1)
+    $format = (int $start, int $lines) ==> ($start === 1 && $lines === 1)
       ? '1'
       : Str\format('%d,%d', $start, $lines);
 


### PR DESCRIPTION
Summary: required for .hhconfig disallow_ambiguous_lambda.

Signed-off-by: Arthur Loiret <arthur.loiret@emerton-data.com>