### PR TITLE
Add methods for the kind of op instead of using `is` expressions

### DIFF
--- a/src/CLIColoredUnifiedDiff.php
+++ b/src/CLIColoredUnifiedDiff.php
@@ -70,11 +70,11 @@ final abstract class CLIColoredUnifiedDiff extends ColoredUnifiedDiff<string> {
   ): string {
     $line = self::DELETE_COLOR.'-';
     foreach ($ops as $op) {
-      if ($op is DiffKeepOp<_>) {
+      if ($op->isKeepOp()) {
         $line .= $op->getContent();
         continue;
       }
-      if ($op is DiffDeleteOp<_>) {
+      if ($op->isDeleteOp()) {
         $line .= self::INTRALINE_DELETE_COLOR.
           $op->getContent().
           self::RESET.
@@ -91,11 +91,11 @@ final abstract class CLIColoredUnifiedDiff extends ColoredUnifiedDiff<string> {
   ): string {
     $line = self::INSERT_COLOR.'+';
     foreach ($ops as $op) {
-      if ($op is DiffKeepOp<_>) {
+      if ($op->isKeepOp()) {
         $line .= $op->getContent();
         continue;
       }
-      if ($op is DiffInsertOp<_>) {
+      if ($op->isInsertOp()) {
         $line .= self::INTRALINE_INSERT_COLOR.
           $op->getContent().
           self::RESET.

--- a/src/ColoredUnifiedDiff.php
+++ b/src/ColoredUnifiedDiff.php
@@ -116,10 +116,10 @@ abstract class ColoredUnifiedDiff<TOut> {
           $words_next = vec(\preg_split('/([^a-zA-Z0-9_]+)/', $next, -1, \PREG_SPLIT_DELIM_CAPTURE));
           $intraline = (new StringDiff($words_line, $words_next))->getDiff();
           $out[] = $intraline
-            |> Vec\filter($$, $op ==> !$op is DiffInsertOp<_>)
+            |> Vec\filter($$, $op ==> !$op->isInsertOp())
             |> static::colorDeleteLineWithIntralineEdits($$);
           $out[] = $intraline
-            |> Vec\filter($$, $op ==> !$op is DiffDeleteOp<_>)
+            |> Vec\filter($$, $op ==> !$op->isDeleteOp())
             |> static::colorInsertLineWithIntralineEdits($$);
           continue;
         }

--- a/src/DiffDeleteOp.php
+++ b/src/DiffDeleteOp.php
@@ -28,6 +28,11 @@ final class DiffDeleteOp<TContent> extends DiffOp<TContent> {
   }
 
   <<__Override>>
+  public function isDeleteOp(): bool {
+    return true;
+  }
+
+  <<__Override>>
   public function asDeleteOp(): DiffDeleteOp<TContent> {
     return $this;
   }

--- a/src/DiffInsertOp.php
+++ b/src/DiffInsertOp.php
@@ -28,6 +28,11 @@ final class DiffInsertOp<TContent> extends DiffOp<TContent> {
   }
 
   <<__Override>>
+  public function isInsertOp(): bool {
+      return true;
+  }
+
+  <<__Override>>
   public function asInsertOp(): DiffInsertOp<TContent> {
     return $this;
   }

--- a/src/DiffKeepOp.php
+++ b/src/DiffKeepOp.php
@@ -33,6 +33,11 @@ final class DiffKeepOp<TContent> extends DiffOp<TContent> {
   }
 
   <<__Override>>
+  public function isKeepOp(): bool {
+    return true;
+  }
+
+  <<__Override>>
   public function asKeepOp(): DiffKeepOp<TContent> {
     return $this;
   }

--- a/src/DiffOp.php
+++ b/src/DiffOp.php
@@ -18,6 +18,18 @@ namespace Facebook\DiffLib;
 abstract class DiffOp<TContent> {
   abstract public function getContent(): TContent;
 
+  public function isDeleteOp(): bool {
+    return false;
+  }
+
+  public function isInsertOp(): bool {
+    return false;
+  }
+
+  public function isKeepOp(): bool {
+    return false;
+  }
+
   public function asDeleteOp(): DiffDeleteOp<TContent> {
     invariant_violation('not a deletion');
   }

--- a/src/StringDiff.php
+++ b/src/StringDiff.php
@@ -40,12 +40,12 @@ final class StringDiff extends Diff {
     $remaining = $this->getDiff();
     $last = C\lastx($remaining);
     // diff -u ignores trailing newlines
-    if ($last is DiffKeepOp<_> && $last->getContent() === '') {
+    if ($last->isKeepOp() && $last->getContent() === '') {
       $remaining = Vec\slice($remaining, 0, C\count($remaining) - 1);
     }
 
     while (!C\is_empty($remaining)) {
-      $not_keep = C\find_key($remaining, $row ==> !$row is DiffKeepOp<_>);
+      $not_keep = C\find_key($remaining, $row ==> !$row->isKeepOp());
       if ($not_keep === null) {
         break;
       }
@@ -57,7 +57,7 @@ final class StringDiff extends Diff {
       $end = $count;
       $run_start = null;
       for ($i = $context; $i < $count; ++$i) {
-        if ($remaining[$i] is DiffKeepOp<_>) {
+        if ($remaining[$i]->isKeepOp()) {
           $run_start ??= $i;
           continue;
         }
@@ -101,7 +101,8 @@ final class StringDiff extends Diff {
     $lines = vec[];
 
     foreach ($hunk as $op) {
-      if ($op is DiffKeepOp<_>) {
+      if ($op->isKeepOp()) {
+        $op = $op->asKeepOp();
         $lines[] = ' '.$op->getContent();
         $old_start ??= $op->getOldPos();
         $new_start ??= $op->getNewPos();
@@ -110,7 +111,8 @@ final class StringDiff extends Diff {
         continue;
       }
 
-      if ($op is DiffDeleteOp<_>) {
+      if ($op->isDeleteOp()) {
+        $op = $op->asDeleteOp();
         $lines[] = '-'.$op->getContent();
         $old_start ??= $op->getOldPos();
         $new_start ??= $op->getOldPos();
@@ -118,7 +120,8 @@ final class StringDiff extends Diff {
         continue;
       }
 
-      if ($op is DiffInsertOp<_>) {
+      if ($op->isInsertOp()) {
+        $op = $op->asInsertOp();
         $lines[] = '+'.$op->getContent();
         $old_start ??= $op->getNewPos();
         $new_start ??= $op->getNewPos();

--- a/src/cluster.php
+++ b/src/cluster.php
@@ -40,21 +40,22 @@ function cluster<T>(
     $cluster ==> {
       $first = C\firstx($cluster);
 
-      if ($first is DiffDeleteOp<_>) {
+      if ($first->isDeleteOp()) {
         return new DiffDeleteOp(
-          $first->getOldPos(),
+          $first->asDeleteOp()->getOldPos(),
           Vec\map($cluster, $op ==> $op->asDeleteOp()->getContent()),
         );
       }
 
-      if ($first is DiffInsertOp<_>) {
+      if ($first->isInsertOp()) {
         return new DiffInsertOp(
-          $first->getNewPos(),
+          $first->asInsertOp()->getNewPos(),
           Vec\map($cluster, $op ==> $op->asInsertOp()->getContent()),
         );
       }
 
-      if ($first is DiffKeepOp<_>) {
+      if ($first->isKeepOp()) {
+        $first = $first->asKeepOp();
         return new DiffKeepOp(
           $first->getOldPos(),
           $first->getNewPos(),


### PR DESCRIPTION
This is a > 75% speedup for `getUnifiedDiff(string $a, string $b)` on
large files when not running in repo-auth mode.