### PR TITLE
bump minimum HHVM version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.25'
+          - '4.56'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
       }
     },
     "require": {
-        "hhvm": "^4.25",
+        "hhvm": "^4.56",
         "hhvm/hsl": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
We can no longer run CI with HHVM 4.25, because ubuntu-latest is now focal (20.04), which HHVM 4.25 doesn't provide packages for.