### PR TITLE
Convert all files to dot-hack files

### DIFF
--- a/src/CLIColoredUnifiedDiff.hack
+++ b/src/CLIColoredUnifiedDiff.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.

--- a/src/ColoredUnifiedDiff.hack
+++ b/src/ColoredUnifiedDiff.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.

--- a/src/Diff.hack
+++ b/src/Diff.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.

--- a/src/DiffDeleteOp.hack
+++ b/src/DiffDeleteOp.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
@@ -10,21 +9,13 @@
 
 namespace Facebook\DiffLib;
 
-/** An operation indicating that this element in the sequence is unchanged */
-final class DiffKeepOp<TContent> extends DiffOp<TContent> {
-  public function __construct(
-    private int $oldPos,
-    private int $newPos,
-    private TContent $content,
-  ) {
+/** An operation representing deleting an element from the original sequence */
+final class DiffDeleteOp<TContent> extends DiffOp<TContent> {
+  public function __construct(private int $oldPos, private TContent $content) {
   }
 
   public function getOldPos(): int {
     return $this->oldPos;
-  }
-
-  public function getNewPos(): int {
-    return $this->newPos;
   }
 
   <<__Override>>
@@ -33,12 +24,12 @@ final class DiffKeepOp<TContent> extends DiffOp<TContent> {
   }
 
   <<__Override>>
-  public function isKeepOp(): bool {
+  public function isDeleteOp(): bool {
     return true;
   }
 
   <<__Override>>
-  public function asKeepOp(): DiffKeepOp<TContent> {
+  public function asDeleteOp(): DiffDeleteOp<TContent> {
     return $this;
   }
 }

--- a/src/DiffInsertOp.hack
+++ b/src/DiffInsertOp.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.

--- a/src/DiffKeepOp.hack
+++ b/src/DiffKeepOp.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
@@ -10,13 +9,21 @@
 
 namespace Facebook\DiffLib;
 
-/** An operation representing deleting an element from the original sequence */
-final class DiffDeleteOp<TContent> extends DiffOp<TContent> {
-  public function __construct(private int $oldPos, private TContent $content) {
+/** An operation indicating that this element in the sequence is unchanged */
+final class DiffKeepOp<TContent> extends DiffOp<TContent> {
+  public function __construct(
+    private int $oldPos,
+    private int $newPos,
+    private TContent $content,
+  ) {
   }
 
   public function getOldPos(): int {
     return $this->oldPos;
+  }
+
+  public function getNewPos(): int {
+    return $this->newPos;
   }
 
   <<__Override>>
@@ -25,12 +32,12 @@ final class DiffDeleteOp<TContent> extends DiffOp<TContent> {
   }
 
   <<__Override>>
-  public function isDeleteOp(): bool {
+  public function isKeepOp(): bool {
     return true;
   }
 
   <<__Override>>
-  public function asDeleteOp(): DiffDeleteOp<TContent> {
+  public function asKeepOp(): DiffKeepOp<TContent> {
     return $this;
   }
 }

--- a/src/DiffOp.hack
+++ b/src/DiffOp.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.

--- a/src/StringDiff.hack
+++ b/src/StringDiff.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.

--- a/src/cluster.hack
+++ b/src/cluster.hack
@@ -1,4 +1,3 @@
-<?hh
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.


### PR DESCRIPTION
This PR intends to make autoload queries that only scan for dot-hh and dot-hack workable with hhvm oss code. The ext_watchman autoloader emits warnings when trying to parse `<?php` files, since they are invalid Hack. Composer emits `<?php` files (and hhvm-autoload contains a `<?php` plugin). Difflib is depended upon by hhast, so it is installed in any code base that uses hhast for linting. This means your autoload query had to scan for dot-php files to allow hhast to work.