### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 tests/ export-ignore
 .hhconfig export-ignore
+.hhvmconfig.hdf export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
         "hhvm/hacktest": "^2.0",
         "facebook/fbexpect": "^2.1.2",
         "hhvm/hhvm-autoload": "^2.0|^3.0"
+    },
+    "config": {
+      "allow-plugins": {
+        "hhvm/hhvm-autoload": true
+      }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
       }
     },
     "require": {
-        "hhvm": "^4.102",
-        "hhvm/hsl": "^4.0"
+        "hhvm": "^4.128"
     },
     "require-dev": {
         "hhvm/hhast": "^4.0",

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -1,5 +1,6 @@
 {
     "roots": ["src/"],
     "devRoots": ["tests/"],
-    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+    "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+    "useFactsIfAvailable": true
 }


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.